### PR TITLE
Make two's compliment explicit early on (in introduction).

### DIFF
--- a/src/j.tex
+++ b/src/j.tex
@@ -1,0 +1,13 @@
+\chapter{``J'' Standard Extension for Dynamically Translated Languages, Version 0.0}
+\label{sec:j}
+
+This chapter is a placeholder for a future standard extension to
+support dynamically translated languages.
+
+\begin{commentary}
+  Many popular languages are usually implemented via dynamic
+  translation, including Java and Javascript. These languages can
+  benefit from additional ISA support for dynamic checks and garbage
+  collection.
+\end{commentary}
+

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -114,7 +114,7 @@ Bit & Character  & Description \\
   6 & G & Additional standard extensions present \\
   7 & H & Hypervisor mode implemented \\
   8 & I & RV32I/64I/128I base ISA \\
-  9 & J & {\em Reserved} \\
+  9 & J & {\em Tentatively reserved for Dynamically Translated Languages extension} \\
  10 & K & {\em Reserved} \\
  11 & L & {\em Tentatively reserved for Decimal Floating-Point extension} \\
  12 & M & Integer Multiply/Divide extension \\

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -134,7 +134,7 @@ Bit & Character  & Description \\
 \hline
 \end{tabular}
 \end{center}
-\caption{Encoding of Base field in {\tt misa}.  All bits that are
+\caption{Encoding of Extensions field in {\tt misa}.  All bits that are
   reserved for future use must return zero when read.}
 \label{misaletters}
 \end{table*}
@@ -311,7 +311,8 @@ of the largest hart ID used in a system.
 \subsection{Machine Status Register ({\tt mstatus})}
 
 The {\tt mstatus} register is an XLEN-bit read/write register
-formatted as shown in Figure~\ref{mstatusreg}.  The {\tt mstatus}
+formatted as shown in Figure~\ref{mstatusreg-rv32} for RV32 and
+Figure~\ref{mstatusreg} for RV64 and RV128.  The {\tt mstatus}
 register keeps track of and controls the hart's current operating
 state.  Restricted views of the {\tt mstatus} register appear as the
 {\tt hstatus} and {\tt sstatus} registers in the H and S
@@ -321,10 +322,11 @@ privilege-level ISAs respectively.
 {\footnotesize
 \begin{center}
 \setlength{\tabcolsep}{4pt}
-\begin{tabular}{cKccccc}
+\begin{tabular}{cKcccccc}
 \\
-\instbit{XLEN-1} &
-\instbitrange{XLEN-2}{20} &
+\instbit{31} &
+\instbitrange{30}{21} &
+\instbit{20} &
 \instbit{19} &
 \instbit{18} &
 \instbit{17} &
@@ -333,13 +335,14 @@ privilege-level ISAs respectively.
 \hline
 \multicolumn{1}{|c|}{SD} &
 \multicolumn{1}{c|}{\wpri} &
+\multicolumn{1}{c|}{TVM} &
 \multicolumn{1}{c|}{MXR} &
 \multicolumn{1}{c|}{PUM} &
 \multicolumn{1}{c|}{MPRV} &
 \multicolumn{1}{c|}{XS[1:0]} &
  \\
 \hline
-1 & XLEN-21 & 1 & 1 & 1 & 2 & \\
+1 & 12 & 1 & 1 & 1 & 1 & 2 & \\
 \end{tabular}
 \begin{tabular}{ccccccccccccc}
 \\
@@ -376,7 +379,78 @@ privilege-level ISAs respectively.
 \end{center}
 }
 \vspace{-0.1in}
-\caption{Machine-mode status register ({\tt mstatus}).}
+\caption{Machine-mode status register ({\tt mstatus}) for RV32.}
+\label{mstatusreg-rv32}
+\end{figure*}
+
+\begin{figure*}[h!]
+{\footnotesize
+\begin{center}
+\setlength{\tabcolsep}{4pt}
+\begin{tabular}{cSccScccccc}
+\\
+\instbit{XLEN-1} &
+\instbitrange{XLEN-2}{36} &
+\instbitrange{35}{34} &
+\instbitrange{33}{32} &
+\instbitrange{31}{21} &
+\instbit{20} &
+\instbit{19} &
+\instbit{18} &
+\instbit{17} &
+\instbitrange{16}{15} &
+ \\
+\hline
+\multicolumn{1}{|c|}{SD} &
+\multicolumn{1}{c|}{\wpri} &
+\multicolumn{1}{c|}{SX} &
+\multicolumn{1}{c|}{UX} &
+\multicolumn{1}{c|}{\wpri} &
+\multicolumn{1}{c|}{TVM} &
+\multicolumn{1}{c|}{MXR} &
+\multicolumn{1}{c|}{PUM} &
+\multicolumn{1}{c|}{MPRV} &
+\multicolumn{1}{c|}{XS[1:0]} &
+ \\
+\hline
+1 & XLEN-37 & 2 & 2 & 11 & 1 & 1 & 1 & 1 & 2 & \\
+\end{tabular}
+\begin{tabular}{ccccccccccccc}
+\\
+&
+\instbitrange{14}{13} &
+\instbitrange{12}{11} &
+\instbitrange{10}{9} &
+\instbit{8} &
+\instbit{7} &
+\instbit{6} &
+\instbit{5} &
+\instbit{4} &
+\instbit{3} &
+\instbit{2} &
+\instbit{1} &
+\instbit{0} \\
+\hline
+ &
+\multicolumn{1}{|c|}{FS[1:0]} &
+\multicolumn{1}{c|}{MPP[1:0]} &
+\multicolumn{1}{c|}{HPP[1:0]} &
+\multicolumn{1}{c|}{SPP} &
+\multicolumn{1}{c|}{MPIE} &
+\multicolumn{1}{c|}{HPIE} &
+\multicolumn{1}{c|}{SPIE} &
+\multicolumn{1}{c|}{UPIE} &
+\multicolumn{1}{c|}{MIE} &
+\multicolumn{1}{c|}{HIE} &
+\multicolumn{1}{c|}{SIE} &
+\multicolumn{1}{c|}{UIE} \\
+\hline
+ & 2 & 2 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1 \\
+\end{tabular}
+\end{center}
+}
+\vspace{-0.1in}
+\caption{Machine-mode status register ({\tt mstatus}) for RV64 and RV128.}
 \label{mstatusreg}
 \end{figure*}
 
@@ -451,6 +525,42 @@ User-level interrupts are primarily intended to support secure
 embedded systems with only M-mode and U-mode present.
 \end{commentary}
 
+\subsection{Base ISA Control in {\tt mstatus} Register}
+
+The SX and UX fields control the value of XLEN for S-mode and U-mode,
+respectively.  The encoding of these fields is the same as that of the Base
+field of {\tt misa}, shown in Table~\ref{misabase}.  These fields only exist
+for RV64 and RV128; RV32 machines always use RV32 for S-mode and U-mode.
+
+The SX field is only implemented if S-mode is implemented, and is otherwise
+hard-wired to zero.  An implementation may limit the values to which SX can be
+set.  The allowed values for SX may be a function of the machine XLEN.
+Changing the machine XLEN (such as by changing the Base field of {\tt misa})
+may cause SX to change as a side effect, regardless of whether the previous
+value of SX would have been compatible with the new machine XLEN.  An
+implementation must enforce that SX specifies a width less than or equal to
+the machine XLEN.  If the Base field of {\tt misa} is always nonzero, an
+implementation may hard-wire SX to be a read-only copy of Base.
+
+The UX field is only implemented if U-mode is implemented, and is otherwise
+hard-wired to zero.  If S-mode is not supported, the allowed values for UX may
+be a function of the machine XLEN.  Changing the machine XLEN (such as by
+changing the Base field of {\tt misa}) may cause UX to change as a side
+effect, regardless of whether the previous value of UX would have been
+compatible with the new machine XLEN.  An implementation must enforce that UX
+specifies a width less than or equal to the machine XLEN.  If the Base field of
+{\tt misa} is always nonzero, an implementation may hard-wire UX to be a
+read-only copy of Base.
+
+If S-mode is supported, the allowed values for UX may be a function of the
+value of field SX.  Changing SX may cause UX to change as a side effect,
+regardless of whether the previous value of UX would have been compatible with
+the new SX.  When an instruction explicitly writes both SX and UX together
+(such as a CSR instruction that writes {\tt mstatus}), the effect is as though
+SX is written first, any side effects from changing SX occur, and then UX is
+written.  An implementation must enforce that UX is no greater than SX, and
+may hard-wire UX to be a read-only copy of SX.
+
 \subsection{Memory Privilege in {\tt mstatus} Register}
 
 The MPRV bit modifies the privilege level at which loads and stores
@@ -483,6 +593,31 @@ accesses to pages that are accessible by U-mode (U=1 in Figure~\ref{sv32pte})
 will fault.  PUM has no effect when page-based virtual memory is not in
 effect.  Note that, while PUM is ordinarily ignored when not executing in
 S-mode, it {\em is} in effect when MPRV=1 and MPP=S.
+
+\subsection{Virtualization Support in {\tt mstatus} Register}
+
+The TVM (Trap Virtual Memory) bit supports intercepting
+supervisor virtual-memory management operations.  When TVM=1,
+attempts to read or write {\tt sptbr} or execute the SFENCE.VMA
+instruction while executing in S-mode will raise an illegal instruction
+exception.  When TVM=0, these operations are permitted in S-mode.
+
+\begin{commentary}
+The TVM mechanism improves virtualization efficiency by permitting guest
+operating systems to execute in S-mode, rather than classically virtualizing
+them in U-mode.  This approach obviates the need to trap accesses to most
+S-mode CSRs.
+
+Trapping {\tt sptbr} accesses and the SFENCE.VMA instruction provides the
+hooks necessary to lazily populate shadow page tables.
+\end{commentary}
+
+\note{AW: Describe TW bit, or make WFI M-only.}
+\begin{commentary}
+Trapping the WFI
+instruction can trigger a world switch to another guest OS, rather than
+wastefully idling in the current guest.
+\end{commentary}
 
 \subsection{Extension Context Status in {\tt mstatus} Register}
 

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -505,20 +505,20 @@ errors that cause invalid entries to be popped off the stack.
 \end{commentary}
 
 {\em x}\,PP fields are \wlrl\ fields that need only be able to store
-supported privilege modes.
+supported privilege modes; however, they must be able to store {\em x}
+and any implemented privilege mode lower than {\em x}.
 
 \begin{commentary}
 If the machine provides only U and M modes, then only a single
 hardware storage bit is required to represent either 00 or 11 in MPP.
-If the machine provides only M mode, then MPP is hardwired to 11.
 \end{commentary}
 
 User-level interrupts are an optional extension and have been
 allocated the ISA extension letter N.
 If user-level interrupts are omitted, the
 UIE and UPIE bits are hardwired to zero.  For all other supported
-privilege modes {\em x}, the {\em x}\,IE, {\em x}\,PIE, and {\em
-  x}\,PP fields are required to be implemented.
+privilege modes {\em x}, the {\em x}\,IE and {\em x}\,PIE must not
+be hardwired.
 
 \begin{commentary}
 User-level interrupts are primarily intended to support secure
@@ -567,13 +567,13 @@ The MPRV bit modifies the privilege level at which loads and stores
 execute.  When MPRV=0, translation and protection behave as normal.  When
 MPRV=1, data memory addresses are translated and protected as though the
 current privilege mode were set to MPP.  Instruction address-translation and
-protection are unaffected.
+protection are unaffected.  MPRV is hardwired to 0 if U-mode is not supported.
 
 The MXR (Make eXecutable Readable) bit modifies the privilege with
 which loads access virtual memory.  When MXR=0, only loads from pages
 marked readable (R=1 in Figure~\ref{sv32pte}) will succeed.  When
 MXR=1, loads from pages marked either readable or executable (R=1 or
-X=1) will succeed.
+X=1) will succeed.  MXR is hardwired to 0 if U-mode is not supported.
 
 \begin{commentary}
 The MPRV and MXR mechanisms were conceived to improve the efficiency of M-mode
@@ -593,6 +593,7 @@ accesses to pages that are accessible by U-mode (U=1 in Figure~\ref{sv32pte})
 will fault.  PUM has no effect when page-based virtual memory is not in
 effect.  Note that, while PUM is ordinarily ignored when not executing in
 S-mode, it {\em is} in effect when MPRV=1 and MPP=S.
+PUM is hard-wired to 0 if S-mode is not supported.
 
 \subsection{Virtualization Support in {\tt mstatus} Register}
 
@@ -1020,6 +1021,10 @@ XLEN \\
 {\tt mideleg} holds trap delegation bits for individual interrupts, with the
 layout of bits matching those in the {\tt mip} register (i.e., STIP interrupt
 delegation control is located in bit 5).
+
+Some exceptions cannot occur at less priveged modes, and corresponding
+{\em x}{\tt edeleg} bits should be hardwired to zero.  In particular,
+{\tt medeleg}[11] and {\tt sedeleg}[11:9] are all hardwired to zero.
 
 \subsection{Machine Interrupt Registers ({\tt mip} and {\tt mie})}
 

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -34,7 +34,7 @@ mechanism.
 \instbitrange{XLEN-3}{26} &
 \instbitrange{25}{0} \\
 \hline
-\multicolumn{1}{|c|}{Base (\warl)} &
+\multicolumn{1}{|c|}{MXL (\warl)} &
 \multicolumn{1}{c|}{\wiri} &
 \multicolumn{1}{c|}{Extensions (\warl)} \\
 \hline
@@ -47,10 +47,10 @@ mechanism.
 \label{misareg}
 \end{figure*}
 
-The Base field encodes the native base integer ISA width as shown in
-Table~\ref{misabase}.  The Base field may be writable in
-implementations that support multiple base ISA widths.  The Base field
-is always set to the widest supported ISA variant at reset.
+The MXL (Machine XLEN) field encodes the native base integer ISA width as
+shown in Table~\ref{misabase}.  The MXL field may be writable in
+implementations that support multiple base ISA widths.  The MXL field is
+always set to the widest supported ISA variant at reset.
 
 \begin{table*}[h!]
 \begin{center}
@@ -64,7 +64,7 @@ Value  & Description \\
 \hline
 \end{tabular}
 \end{center}
-\caption{Encoding of Base field in {\tt misa}}
+\caption{Encoding of MXL field in {\tt misa}}
 \label{misabase}
 \end{table*}
 
@@ -73,7 +73,7 @@ The base can be quickly ascertained using branches on the sign of the
 returned {\tt misa} value, and possibly a shift left by one and a
 second branch on the sign.  These checks can be written in assembly
 code without knowing the register width (XLEN) of the machine.
-The base width is given by $XLEN=2^{Base+4}$.
+The base width is given by $XLEN=2^{MXL+4}$.
 \end{commentary}
 
 The Extensions field encodes the presence of the standard extensions,
@@ -532,29 +532,29 @@ embedded systems with only M-mode and U-mode present.
 \subsection{Base ISA Control in {\tt mstatus} Register}
 
 The SXL and UXL fields control the value of XLEN for S-mode and U-mode,
-respectively.  The encoding of these fields is the same as that of the Base
+respectively.  The encoding of these fields is the same as that of the MXL
 field of {\tt misa}, shown in Table~\ref{misabase}.  These fields only exist
 for RV64 and RV128; RV32 machines always use RV32 for S-mode and U-mode.
 
 The SXL field is only implemented if S-mode is implemented, and is otherwise
 hard-wired to zero.  An implementation may limit the values to which SXL can be
 set.  The allowed values for SXL may be a function of the machine XLEN.
-Changing the machine XLEN (such as by changing the Base field of {\tt misa})
+Changing the machine XLEN (such as by changing the MXL field of {\tt misa})
 may cause SXL to change as a side effect, regardless of whether the previous
 value of SXL would have been compatible with the new machine XLEN.  An
 implementation must enforce that SXL specifies a width less than or equal to
-the machine XLEN.  If the Base field of {\tt misa} is always nonzero, an
-implementation may hard-wire SXL to be a read-only copy of Base.
+the machine XLEN.  If the MXL field of {\tt misa} is always nonzero, an
+implementation may hard-wire SXL to be a read-only copy of MXL.
 
 The UXL field is only implemented if U-mode is implemented, and is otherwise
 hard-wired to zero.  If S-mode is not supported, the allowed values for UXL may
 be a function of the machine XLEN.  Changing the machine XLEN (such as by
-changing the Base field of {\tt misa}) may cause UXL to change as a side
+changing the MXL field of {\tt misa}) may cause UXL to change as a side
 effect, regardless of whether the previous value of UXL would have been
 compatible with the new machine XLEN.  An implementation must enforce that UXL
-specifies a width less than or equal to the machine XLEN.  If the Base field of
+specifies a width less than or equal to the machine XLEN.  If the MXL field of
 {\tt misa} is always nonzero, an implementation may hard-wire UXL to be a
-read-only copy of Base.
+read-only copy of MXL.
 
 If S-mode is supported, the allowed values for UXL may be a function of the
 value of field SXL.  Changing SXL may cause UXL to change as a side effect,

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -325,28 +325,29 @@ privilege-level ISAs respectively.
 \begin{tabular}{cKcccccc}
 \\
 \instbit{31} &
-\instbitrange{30}{21} &
+\instbitrange{30}{22} &
+\instbit{21} &
 \instbit{20} &
 \instbit{19} &
 \instbit{18} &
 \instbit{17} &
-\instbitrange{16}{15} &
  \\
 \hline
 \multicolumn{1}{|c|}{SD} &
 \multicolumn{1}{c|}{\wpri} &
+\multicolumn{1}{c|}{TW} &
 \multicolumn{1}{c|}{TVM} &
 \multicolumn{1}{c|}{MXR} &
 \multicolumn{1}{c|}{PUM} &
 \multicolumn{1}{c|}{MPRV} &
-\multicolumn{1}{c|}{XS[1:0]} &
  \\
 \hline
-1 & 12 & 1 & 1 & 1 & 1 & 2 & \\
+1 & 9 & 1 & 1 & 1 & 1 & 1 & \\
 \end{tabular}
-\begin{tabular}{ccccccccccccc}
+\begin{tabular}{cccccccccccccc}
 \\
 &
+\instbitrange{16}{15} &
 \instbitrange{14}{13} &
 \instbitrange{12}{11} &
 \instbitrange{10}{9} &
@@ -361,6 +362,7 @@ privilege-level ISAs respectively.
 \instbit{0} \\
 \hline
  &
+\multicolumn{1}{c|}{XS[1:0]} &
 \multicolumn{1}{|c|}{FS[1:0]} &
 \multicolumn{1}{c|}{MPP[1:0]} &
 \multicolumn{1}{c|}{HPP[1:0]} &
@@ -393,12 +395,12 @@ privilege-level ISAs respectively.
 \instbitrange{XLEN-2}{36} &
 \instbitrange{35}{34} &
 \instbitrange{33}{32} &
-\instbitrange{31}{21} &
+\instbitrange{31}{20} &
+\instbit{21} &
 \instbit{20} &
 \instbit{19} &
 \instbit{18} &
 \instbit{17} &
-\instbitrange{16}{15} &
  \\
 \hline
 \multicolumn{1}{|c|}{SD} &
@@ -406,18 +408,19 @@ privilege-level ISAs respectively.
 \multicolumn{1}{c|}{SXL} &
 \multicolumn{1}{c|}{UXL} &
 \multicolumn{1}{c|}{\wpri} &
+\multicolumn{1}{c|}{TW} &
 \multicolumn{1}{c|}{TVM} &
 \multicolumn{1}{c|}{MXR} &
 \multicolumn{1}{c|}{PUM} &
 \multicolumn{1}{c|}{MPRV} &
-\multicolumn{1}{c|}{XS[1:0]} &
  \\
 \hline
-1 & XLEN-37 & 2 & 2 & 11 & 1 & 1 & 1 & 1 & 2 & \\
+1 & XLEN-37 & 2 & 2 & 10 & 1 & 1 & 1 & 1 & 1 & \\
 \end{tabular}
-\begin{tabular}{ccccccccccccc}
+\begin{tabular}{cccccccccccccc}
 \\
 &
+\instbitrange{16}{15} &
 \instbitrange{14}{13} &
 \instbitrange{12}{11} &
 \instbitrange{10}{9} &
@@ -432,6 +435,7 @@ privilege-level ISAs respectively.
 \instbit{0} \\
 \hline
  &
+\multicolumn{1}{c|}{XS[1:0]} &
 \multicolumn{1}{|c|}{FS[1:0]} &
 \multicolumn{1}{c|}{MPP[1:0]} &
 \multicolumn{1}{c|}{HPP[1:0]} &
@@ -445,7 +449,7 @@ privilege-level ISAs respectively.
 \multicolumn{1}{c|}{SIE} &
 \multicolumn{1}{c|}{UIE} \\
 \hline
- & 2 & 2 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1 \\
+ & 2 & 2 & 2 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1 \\
 \end{tabular}
 \end{center}
 }
@@ -602,6 +606,7 @@ supervisor virtual-memory management operations.  When TVM=1,
 attempts to read or write {\tt sptbr} or execute the SFENCE.VMA
 instruction while executing in S-mode will raise an illegal instruction
 exception.  When TVM=0, these operations are permitted in S-mode.
+TVM is hard-wired to 0 when S-mode is not supported.
 
 \begin{commentary}
 The TVM mechanism improves virtualization efficiency by permitting guest
@@ -613,7 +618,14 @@ Trapping {\tt sptbr} accesses and the SFENCE.VMA instruction provides the
 hooks necessary to lazily populate shadow page tables.
 \end{commentary}
 
-\note{AW: Describe TW bit, or make WFI M-only.}
+The TW (Timeout Wait) bit supports intercepting the WFI instruction (see
+Section~\ref{wfi}).  When TW=0, the WFI instruction is permitted in S-mode.
+When TW=1, if WFI is executed in S-mode, and it does not complete within an
+implementation-specific, bounded time limit, the WFI instruction causes an
+illegal instruction trap.  The time limit may always be 0, in which case WFI
+always causes an illegal instruction trap in S-mode when TW=1.
+TW is hard-wired to 0 when S-mode is not supported.
+
 \begin{commentary}
 Trapping the WFI
 instruction can trigger a world switch to another guest OS, rather than

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -403,8 +403,8 @@ privilege-level ISAs respectively.
 \hline
 \multicolumn{1}{|c|}{SD} &
 \multicolumn{1}{c|}{\wpri} &
-\multicolumn{1}{c|}{SX} &
-\multicolumn{1}{c|}{UX} &
+\multicolumn{1}{c|}{SXL} &
+\multicolumn{1}{c|}{UXL} &
 \multicolumn{1}{c|}{\wpri} &
 \multicolumn{1}{c|}{TVM} &
 \multicolumn{1}{c|}{MXR} &
@@ -527,39 +527,39 @@ embedded systems with only M-mode and U-mode present.
 
 \subsection{Base ISA Control in {\tt mstatus} Register}
 
-The SX and UX fields control the value of XLEN for S-mode and U-mode,
+The SXL and UXL fields control the value of XLEN for S-mode and U-mode,
 respectively.  The encoding of these fields is the same as that of the Base
 field of {\tt misa}, shown in Table~\ref{misabase}.  These fields only exist
 for RV64 and RV128; RV32 machines always use RV32 for S-mode and U-mode.
 
-The SX field is only implemented if S-mode is implemented, and is otherwise
-hard-wired to zero.  An implementation may limit the values to which SX can be
-set.  The allowed values for SX may be a function of the machine XLEN.
+The SXL field is only implemented if S-mode is implemented, and is otherwise
+hard-wired to zero.  An implementation may limit the values to which SXL can be
+set.  The allowed values for SXL may be a function of the machine XLEN.
 Changing the machine XLEN (such as by changing the Base field of {\tt misa})
-may cause SX to change as a side effect, regardless of whether the previous
-value of SX would have been compatible with the new machine XLEN.  An
-implementation must enforce that SX specifies a width less than or equal to
+may cause SXL to change as a side effect, regardless of whether the previous
+value of SXL would have been compatible with the new machine XLEN.  An
+implementation must enforce that SXL specifies a width less than or equal to
 the machine XLEN.  If the Base field of {\tt misa} is always nonzero, an
-implementation may hard-wire SX to be a read-only copy of Base.
+implementation may hard-wire SXL to be a read-only copy of Base.
 
-The UX field is only implemented if U-mode is implemented, and is otherwise
-hard-wired to zero.  If S-mode is not supported, the allowed values for UX may
+The UXL field is only implemented if U-mode is implemented, and is otherwise
+hard-wired to zero.  If S-mode is not supported, the allowed values for UXL may
 be a function of the machine XLEN.  Changing the machine XLEN (such as by
-changing the Base field of {\tt misa}) may cause UX to change as a side
-effect, regardless of whether the previous value of UX would have been
-compatible with the new machine XLEN.  An implementation must enforce that UX
+changing the Base field of {\tt misa}) may cause UXL to change as a side
+effect, regardless of whether the previous value of UXL would have been
+compatible with the new machine XLEN.  An implementation must enforce that UXL
 specifies a width less than or equal to the machine XLEN.  If the Base field of
-{\tt misa} is always nonzero, an implementation may hard-wire UX to be a
+{\tt misa} is always nonzero, an implementation may hard-wire UXL to be a
 read-only copy of Base.
 
-If S-mode is supported, the allowed values for UX may be a function of the
-value of field SX.  Changing SX may cause UX to change as a side effect,
-regardless of whether the previous value of UX would have been compatible with
-the new SX.  When an instruction explicitly writes both SX and UX together
+If S-mode is supported, the allowed values for UXL may be a function of the
+value of field SXL.  Changing SXL may cause UXL to change as a side effect,
+regardless of whether the previous value of UXL would have been compatible with
+the new SXL.  When an instruction explicitly writes both SXL and UXL together
 (such as a CSR instruction that writes {\tt mstatus}), the effect is as though
-SX is written first, any side effects from changing SX occur, and then UX is
-written.  An implementation must enforce that UX is no greater than SX, and
-may hard-wire UX to be a read-only copy of SX.
+SXL is written first, any side effects from changing SXL occur, and then UXL is
+written.  An implementation must enforce that UXL is no greater than SXL, and
+may hard-wire UXL to be a read-only copy of SXL.
 
 \subsection{Memory Privilege in {\tt mstatus} Register}
 

--- a/src/machine.tex
+++ b/src/machine.tex
@@ -834,6 +834,14 @@ supported delegatable bits found by writing one to every bit location,
 then reading back the value in {\tt medeleg} or {\tt mideleg} to see
 which bit positions hold a one.
 
+Traps never transition from a more-privileged mode to a less-privileged mode.
+For example, if M-mode has delegated illegal instruction traps to S-mode, and
+M-mode software later executes an illegal instruction, the trap is taken in
+M-mode, rather than being delegated to S-mode.  By contrast, traps may be
+taken horizontally.  Using the same example, if M-mode has delegated illegal
+instruction traps to S-mode, and S-mode software later executes an illegal
+instruction, the trap is taken in S-mode.
+
 \begin{figure}[h!]
 {\footnotesize
 \begin{center}

--- a/src/naming.tex
+++ b/src/naming.tex
@@ -112,6 +112,7 @@ Quad-Precision Floating-Point & Q \\
 Decimal Floating-Point & L \\
 16-bit Compressed Instructions & C \\
 Bit Manipulation & B \\
+Dynamic Languages & J \\
 Transactional Memory & T \\
 Packed-SIMD Extensions & P \\
 Vector Extensions & V \\

--- a/src/preface.tex
+++ b/src/preface.tex
@@ -25,6 +25,7 @@ versions of the RISC-V ISA modules:
     C        & 1.9 & N \\
     V        & 0.1 & N \\
     B        & 0.0 & N \\
+    J        & 0.0 & N \\
     T        & 0.0 & N \\
     P        & 0.1 & N \\
     \hline

--- a/src/priv-csrs.tex
+++ b/src/priv-csrs.tex
@@ -282,16 +282,16 @@ Number    & Privilege & Name & Description \\
 \hline
 \multicolumn{4}{|c|}{Machine Protection and Translation} \\
 \hline
-\tt 0x380 & MRW  &\tt mbase      & Base register. \\
-\tt 0x381 & MRW  &\tt mbound     & Bound register. \\
-\tt 0x382 & MRW  &\tt mibase     & Instruction base register. \\
-\tt 0x383 & MRW  &\tt mibound    & Instruction bound register. \\
-\tt 0x384 & MRW  &\tt mdbase     & Data base register. \\
-\tt 0x385 & MRW  &\tt mdbound    & Data bound register. \\
-%\tt 0x3A0 & MRW  &\tt pmpselect  & Physical memory protection register select. \\
-%\tt 0x3A1 & MRW  &\tt pmpdata1   & Physical memory protection data register. \\
-%\tt 0x3A2 & MRW  &\tt pmpdata2   & Physical memory protection data register. \\
-%\tt 0x3A3 & MRW  &\tt pmpdata3   & Physical memory protection data register. \\
+%\tt 0x380 & MRW  &\tt mbase      & Base register. \\
+%\tt 0x381 & MRW  &\tt mbound     & Bound register. \\
+%\tt 0x382 & MRW  &\tt mibase     & Instruction base register. \\
+%\tt 0x383 & MRW  &\tt mibound    & Instruction bound register. \\
+%\tt 0x384 & MRW  &\tt mdbase     & Data base register. \\
+%\tt 0x385 & MRW  &\tt mdbound    & Data bound register. \\
+\tt 0x3A0 & MRW  &\tt pmpselect  & Physical memory protection register select. \\
+\tt 0x3A1 & MRW  &\tt pmpdata1   & Physical memory protection data register. \\
+\tt 0x3A2 & MRW  &\tt pmpdata2   & Physical memory protection data register. \\
+\tt 0x3A3 & MRW  &\tt pmpdata3   & Physical memory protection data register. \\
 \hline
 \end{tabular}
 \end{center}

--- a/src/priv-history.tex
+++ b/src/priv-history.tex
@@ -3,7 +3,7 @@
 \section*{Acknowledgments}
 
 Thanks to Jacob Bachmeyer,
-Allen J. Baum, Ruslan Bukin, Christopher Celio, David
+Allen J. Baum, Paolo Bonzini, Ruslan Bukin, Christopher Celio, David
 Chisnall, Palmer Dabbelt, Monte Dalrymple, Dennis Ferguson, Mike
 Frysinger, John Hauser, Jonathan Neusch{\"a}fer, Rishiyur Nikhil, Stefan O'Rear,
 Albert Ou, John Ousterhout, Colin Schmidt, Wesley Terpstra, Matt

--- a/src/priv-history.tex
+++ b/src/priv-history.tex
@@ -2,9 +2,10 @@
 
 \section*{Acknowledgments}
 
-Thanks to Allen J. Baum, Ruslan Bukin, Christopher Celio, David
+Thanks to Jacob Bachmeyer,
+Allen J. Baum, Ruslan Bukin, Christopher Celio, David
 Chisnall, Palmer Dabbelt, Monte Dalrymple, Dennis Ferguson, Mike
-Frysinger, Jonathan Neusch{\"a}fer, Rishiyur Nikhil, Stefan O'Rear,
+Frysinger, John Hauser, Jonathan Neusch{\"a}fer, Rishiyur Nikhil, Stefan O'Rear,
 Albert Ou, John Ousterhout, Colin Schmidt, Wesley Terpstra, Matt
 Thomas, Tommy Thorn, Ray VanDeWalker, and Reinoud Zandijk for feedback
 on the privileged specification.

--- a/src/priv-history.tex
+++ b/src/priv-history.tex
@@ -5,7 +5,8 @@
 Thanks to Jacob Bachmeyer,
 Allen J. Baum, Paolo Bonzini, Ruslan Bukin, Christopher Celio, David
 Chisnall, Palmer Dabbelt, Monte Dalrymple, Dennis Ferguson, Mike
-Frysinger, John Hauser, Jonathan Neusch{\"a}fer, Rishiyur Nikhil, Stefan O'Rear,
+Frysinger, John Hauser, David Horner,
+Jonathan Neusch{\"a}fer, Rishiyur Nikhil, Stefan O'Rear,
 Albert Ou, John Ousterhout, Colin Schmidt, Wesley Terpstra, Matt
 Thomas, Tommy Thorn, Ray VanDeWalker, and Reinoud Zandijk for feedback
 on the privileged specification.

--- a/src/priv-preface.tex
+++ b/src/priv-preface.tex
@@ -6,6 +6,10 @@ proposal.  Changes from version 1.9.1 include:
 \begin{itemize}
   \parskip 0pt
   \itemsep 1pt
+\item A optional mechanism to change the base ISA used by supervisor and user
+      modes has bee added.
+\item A mechanism to improve virtualization performance by
+      trapping S-mode virtual-memory management operations has been added.
 \item The supervisor virtual memory configuration has been moved from the
       {\tt mstatus} register to the {\tt sptbr} register.
 \item The SFENCE.VM instruction has been removed in favor of the improved

--- a/src/riscv-spec.tex
+++ b/src/riscv-spec.tex
@@ -59,6 +59,7 @@ International License.
 \input{c}
 \input{v}
 \input{b}
+\input{j}
 \input{t}
 \input{p}
 \input{rv128}

--- a/src/sbi.tex
+++ b/src/sbi.tex
@@ -54,7 +54,7 @@ void sbi_shutdown(void); & Terminate this supervisor-mode process. \\ \hline
 int sbi_console_putchar(uint8_t ch); & Write byte to debug console (blocking); returns 0 on success, else -1. \\ \hline
 int sbi_console_getchar(void); & Read byte from debug console; returns the byte on success, or -1 for failure. \\ \hline
 
-& \multirow{4}{*}{\parbox{8cm}{Instruct other harts to execute SFENCE.VM.  {\tt harts} points to a bitmask of remote hart IDs; NULL indicates all harts.  {\tt asid} holds the address-space ID; 0 indicates all address spaces.}} \\
+& \multirow{4}{*}{\parbox{8cm}{Instruct other harts to execute SFENCE.VMA.  {\tt harts} points to a bitmask of remote hart IDs; NULL indicates all harts.  {\tt asid} holds the address-space ID; 0 indicates all address spaces.}} \\
 void sbi_remote_sfence_vm( & \\
 \ \ const uintptr_t* harts, size_t asid); & \\
 & \\ \hline

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -127,7 +127,7 @@ sstatus} is equivalent to reading or writing the homonymous field in
 \subsection{Base ISA Control in {\tt sstatus} Register}
 
 The UXL field controls the value of XLEN for U-mode.  The encoding of UXL is the
-same as that of the Base field of {\tt misa}, shown in Table~\ref{misabase}.
+same as that of the MXL field of {\tt misa}, shown in Table~\ref{misabase}.
 This field only exists for RV64 and RV128; RV32 machines always use RV32 for
 U-mode.  An implementation may limit the values to which UXL can be set, but
 U-mode XLEN must not exceed S-mode XLEN.

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -124,6 +124,16 @@ sstatus} is equivalent to reading or writing the homonymous field in
 {\tt mstatus}.
 \end{commentary}
 
+\subsection{Base ISA Control in {\tt sstatus} Register}
+
+The UX field controls the value of XLEN for U-mode.  The encoding of UX is the
+same as that of the Base field of {\tt misa}, shown in Table~\ref{misabase}.
+This field only exists for RV64 and RV128; RV32 machines always use RV32 for
+U-mode.  An implementation may limit the values to which UX can be set, but
+U-mode XLEN must not exceed S-mode XLEN.
+
+\note{AW: add this to sstatus figure}
+
 \subsection{Memory Privilege in {\tt sstatus} Register}
 \label{sec:pum}
 

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -525,7 +525,7 @@ current address-translation scheme.
 \begin{figure}[h!]
 {\footnotesize
 \begin{center}
-\begin{tabular}{c@{}S@{}M}
+\begin{tabular}{c@{}E@{}K}
 \instbit{31} &
 \instbitrange{30}{22} &
 \instbitrange{21}{0} \\
@@ -551,24 +551,22 @@ a physical address space larger than \wunits{4}{GiB} for RV32.
 \begin{figure}[h!]
 {\footnotesize
 \begin{center}
-\begin{tabular}{@{}S@{}E@{}R@{}K}
-\instbitrange{63}{61} &
-\instbitrange{60}{45} &
-\instbitrange{44}{38} &
-\instbitrange{37}{0} \\
+\begin{tabular}{@{}S@{}T@{}U}
+\instbitrange{63}{60} &
+\instbitrange{59}{44} &
+\instbitrange{43}{0} \\
 \hline
 \multicolumn{1}{|c|}{{\tt MODE} (\warl)} &
 \multicolumn{1}{|c|}{{\tt ASID} (\warl)} &
-\multicolumn{1}{|c|}{0 (\wlrl)} &
 \multicolumn{1}{|c|}{{\tt PPN}  (\warl)} \\
 \hline
-3 & 16 & 7 & 38 \\
+4 & 16 & 44 \\
 \end{tabular}
 \end{center}
 }
 \vspace{-0.1in}
 \caption{RV64 Supervisor Page-Table Base Register {\tt sptbr}, for MODE
-values Sv39, Sv48, Sv57, and Sv64.}
+values Sv39 and Sv48.}
 \label{rv64ptbrreg}
 \end{figure}
 
@@ -590,11 +588,14 @@ have no effect.
 For RV32, the only other valid setting for MODE is Sv32, a paged
 virtual-memory scheme described in Section~\ref{sec:sv32}.
 
-For RV64, four paged virtual-memory schemes are defined: Sv39, Sv48, Sv57, and
-Sv64, described in Sections~\ref{sec:sv39}, \ref{sec:sv48}, \ref{sec:sv57},
-and \ref{sec:sv64}, respectively.  The remaining MODE settings are reserved
+For RV64, two paged virtual-memory schemes are defined: Sv39 and Sv48,
+described in Sections~\ref{sec:sv39} and \ref{sec:sv48}, respectively.
+Two additional schemes, Sv57 and Sv64, will be defined in a later version
+of this specification.  The remaining MODE settings are reserved
 for future use and may define different interpretations of the other fields in
-{\tt sptbr}.  Implementations are not required to support all MODE settings,
+{\tt sptbr}.
+
+Implementations are not required to support all MODE settings,
 and if {\tt sptbr} is written with an unsupported MODE, the entire write has
 no effect; no fields in {\tt sptbr} are modified.
 
@@ -614,11 +615,12 @@ Value  & Name & Description \\
 Value  & Name & Description \\
 \hline  
 0       & P     & No translation or protection. \\
-1--3    & ---   & {\em Reserved} \\
-4       & Sv39  & Page-based 39-bit virtual addressing. \\
-5       & Sv48  & Page-based 48-bit virtual addressing. \\
-6       & Sv57 &  Page-based 57-bit virtual addressing. \\
-7       & Sv64 &  Page-based 64-bit virtual addressing. \\
+1--7    & ---   & {\em Reserved} \\
+8       & Sv39  & Page-based 39-bit virtual addressing. \\
+9       & Sv48  & Page-based 48-bit virtual addressing. \\
+10      & {\em Sv57} & {\em Reserved for page-based 57-bit virtual addressing.} \\
+11      & {\em Sv64} & {\em Reserved for page-based 64-bit virtual addressing.} \\
+12--15  & ---   & {\em Reserved} \\
 \hline
 \end{tabular}
 \end{center}
@@ -1020,11 +1022,11 @@ design of Sv39 follows the overall scheme of Sv32, and this section
 details only the differences between the schemes.
 
 \begin{commentary}
-We specified four virtual memory systems for RV64 to relieve the tension
+We specified multiple virtual memory systems for RV64 to relieve the tension
 between providing a large address space and minimizing address-translation
 cost.  For many systems, \wunits{512}{GiB} of virtual-address space is ample,
-and so Sv39 suffices.  Sv48, Sv57, and Sv64 increase the virtual address space
-to terabytes, petabytes, and exabytes, but increase the physical memory
+and so Sv39 suffices.  Sv48 increases the virtual address space to
+\wunits{256}{TiB}, but increases the phyiscal memory
 capacity dedicated to page tables, the latency of page-table traversals, and
 the size of hardware structures that store virtual addresses.
 \end{commentary}
@@ -1285,267 +1287,3 @@ physically aligned to a boundary equal to its size.
 The algorithm for virtual-to-physical address translation is the same
 as in Section~\ref{sv32algorithm}, except LEVELS equals 4 and PTESIZE
 equals 8.
-
-\section{Sv57: Page-Based 57-bit Virtual-Memory System}
-\label{sec:sv57}
-
-This section describes a simple paged virtual-memory system designed for RV64
-systems, which supports 57-bit virtual address spaces.  It closely follows the
-design of Sv39 and Sv48, simply adding an additional level of page table to
-the latter, and so this chapter only details the differences between the two
-schemes.
-
-Implementations that support Sv57 should also support Sv39 and Sv48.
-
-\subsection{Addressing and Memory Protection}
-
-Sv57 implementations support a 57-bit virtual address space, divided
-into \wunits{4}{KiB} pages.  An Sv57 address is partitioned as
-shown in Figure~\ref{sv57va}.  Load and store effective addresses,
-which are 64 bits, must have bits 63--57 all equal to bit 56, or else
-an access fault will occur.  The 45-bit VPN is translated into a
-38-bit PPN via a four-level page table, while the 12-bit page offset
-is untranslated.
-
-\begin{figure*}[h!]
-{\footnotesize
-\begin{center}
-\begin{tabular}{@{}S@{}S@{}S@{}S@{}S@{}S}
-\instbitrange{56}{48} &
-\instbitrange{47}{39} &
-\instbitrange{38}{30} &
-\instbitrange{29}{21} &
-\instbitrange{20}{12} &
-\instbitrange{11}{0} \\
-\hline
-\multicolumn{1}{|c|}{VPN[4]} &
-\multicolumn{1}{c|}{VPN[3]} &
-\multicolumn{1}{c|}{VPN[2]} &
-\multicolumn{1}{c|}{VPN[1]} &
-\multicolumn{1}{c|}{VPN[0]} &
-\multicolumn{1}{c|}{page offset} \\
-\hline
-9 & 9 & 9 & 9 & 9 & 12 \\
-\end{tabular}
-\end{center}
-}
-\vspace{-0.1in}
-\caption{Sv57 virtual address.}
-\label{sv57va}
-\end{figure*}
-
-\begin{figure*}[h!]
-{\footnotesize
-\begin{center}
-\begin{tabular}{@{}F@{}S@{}S@{}S@{}S@{}S}
-\instbitrange{49}{48} &
-\instbitrange{47}{39} &
-\instbitrange{38}{30} &
-\instbitrange{29}{21} &
-\instbitrange{20}{12} &
-\instbitrange{11}{0} \\
-\hline
-\multicolumn{1}{|c|}{PPN[4]} &
-\multicolumn{1}{c|}{PPN[3]} &
-\multicolumn{1}{c|}{PPN[2]} &
-\multicolumn{1}{c|}{PPN[1]} &
-\multicolumn{1}{c|}{PPN[0]} &
-\multicolumn{1}{c|}{page offset} \\
-\hline
-2 & 9 & 9 & 9 & 9 & 12 \\
-\end{tabular}
-\end{center}
-}
-\vspace{-0.1in}
-\caption{Sv57 physical address.}
-\label{sv57pa}
-\end{figure*}
-
-\begin{figure*}[h!]
-{\footnotesize
-\begin{center}
-\begin{tabular}{@{}Y@{}F@{}F@{}F@{}F@{}F@{}Fcccccccc}
-\instbitrange{63}{48} &
-\instbitrange{47}{46} &
-\instbitrange{45}{37} &
-\instbitrange{36}{28} &
-\instbitrange{27}{19} &
-\instbitrange{18}{10} &
-\instbitrange{9}{8} &
-\instbit{7} &
-\instbit{6} &
-\instbit{5} &
-\instbit{4} &
-\instbit{3} &
-\instbit{2} &
-\instbit{1} &
-\instbit{0} \\
-\hline
-\multicolumn{1}{|c|}{\it Reserved} &
-\multicolumn{1}{c|}{PPN[4]} &
-\multicolumn{1}{c|}{PPN[3]} &
-\multicolumn{1}{c|}{PPN[2]} &
-\multicolumn{1}{c|}{PPN[1]} &
-\multicolumn{1}{c|}{PPN[0]} &
-\multicolumn{1}{c|}{RSW} &
-\multicolumn{1}{c|}{D} &
-\multicolumn{1}{c|}{A} &
-\multicolumn{1}{c|}{G} &
-\multicolumn{1}{c|}{U} &
-\multicolumn{1}{c|}{X} &
-\multicolumn{1}{c|}{W} &
-\multicolumn{1}{c|}{R} &
-\multicolumn{1}{c|}{V} \\
-\hline
-16 & 2 & 9 & 9 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
-\end{tabular}
-\end{center}
-}
-\vspace{-0.1in}
-\caption{Sv57 page table entry.}
-\label{sv57pte}
-\end{figure*}
-
-The PTE format for Sv57 is shown in Figure~\ref{sv57pte}.  Bits 9--0
-have the same meaning as for Sv32.  Any level of PTE may be a leaf
-PTE, so in addition to \wunits{4}{KiB} pages, Sv57 supports
-\wunits{2}{MiB} {\em megapages}, \wunits{1}{GiB} {\em gigapages},
-\wunits{512}{GiB} {\em terapages}, and \wunits{256}{TiB} {\em petapages},
-each of which must be virtually and
-physically aligned to a boundary equal to its size.
-
-The algorithm for virtual-to-physical address translation is the same
-as in Section~\ref{sv32algorithm}, except LEVELS equals 5 and PTESIZE
-equals 8.
-
-\section{Sv64: Page-Based 64-bit Virtual-Memory System}
-\label{sec:sv64}
-
-This section describes a simple paged virtual-memory system designed for RV64
-systems, which supports 64-bit virtual address spaces.  It closely follows the
-design of Sv39, Sv48, and Sv57, simply adding an additional level of page table to
-the latter, and so this chapter only details the differences between the two
-schemes.
-
-Implementations that support Sv64 should also support Sv39, Sv48, and Sv57.
-
-\subsection{Addressing and Memory Protection}
-
-Sv64 implementations support a 64-bit virtual address space, divided
-into \wunits{4}{KiB} pages.  An Sv64 address is partitioned as
-shown in Figure~\ref{sv64va}.  The 52-bit VPN is translated into a
-38-bit PPN via a four-level page table, while the 12-bit page offset
-is untranslated.
-
-\begin{figure*}[h!]
-{\footnotesize
-\begin{center}
-\begin{tabular}{@{}Y@{}R@{}R@{}R@{}R@{}R@{}R}
-\instbitrange{63}{57} &
-\instbitrange{56}{48} &
-\instbitrange{47}{39} &
-\instbitrange{38}{30} &
-\instbitrange{29}{21} &
-\instbitrange{20}{12} &
-\instbitrange{11}{0} \\
-\hline
-\multicolumn{1}{|c|}{VPN[5]} &
-\multicolumn{1}{c|}{VPN[4]} &
-\multicolumn{1}{c|}{VPN[3]} &
-\multicolumn{1}{c|}{VPN[2]} &
-\multicolumn{1}{c|}{VPN[1]} &
-\multicolumn{1}{c|}{VPN[0]} &
-\multicolumn{1}{c|}{page offset} \\
-\hline
-7 & 9 & 9 & 9 & 9 & 9 & 12 \\
-\end{tabular}
-\end{center}
-}
-\vspace{-0.1in}
-\caption{Sv64 virtual address.}
-\label{sv64va}
-\end{figure*}
-
-\begin{figure*}[h!]
-{\footnotesize
-\begin{center}
-\begin{tabular}{@{}F@{}S@{}S@{}S@{}S@{}S}
-\instbitrange{49}{48} &
-\instbitrange{47}{39} &
-\instbitrange{38}{30} &
-\instbitrange{29}{21} &
-\instbitrange{20}{12} &
-\instbitrange{11}{0} \\
-\hline
-\multicolumn{1}{|c|}{PPN[4]} &
-\multicolumn{1}{c|}{PPN[3]} &
-\multicolumn{1}{c|}{PPN[2]} &
-\multicolumn{1}{c|}{PPN[1]} &
-\multicolumn{1}{c|}{PPN[0]} &
-\multicolumn{1}{c|}{page offset} \\
-\hline
-2 & 9 & 9 & 9 & 9 & 12 \\
-\end{tabular}
-\end{center}
-}
-\vspace{-0.1in}
-\caption{Sv64 physical address.}
-\label{sv64pa}
-\end{figure*}
-
-\begin{figure*}[h!]
-{\footnotesize
-\begin{center}
-\begin{tabular}{@{}F@{}F@{}F@{}F@{}F@{}F@{}Fcccccccc}
-\instbitrange{63}{48} &
-\instbitrange{47}{46} &
-\instbitrange{45}{37} &
-\instbitrange{36}{28} &
-\instbitrange{27}{19} &
-\instbitrange{18}{10} &
-\instbitrange{9}{8} &
-\instbit{7} &
-\instbit{6} &
-\instbit{5} &
-\instbit{4} &
-\instbit{3} &
-\instbit{2} &
-\instbit{1} &
-\instbit{0} \\
-\hline
-\multicolumn{1}{|c|}{\it Reserved} &
-\multicolumn{1}{c|}{PPN[4]} &
-\multicolumn{1}{c|}{PPN[3]} &
-\multicolumn{1}{c|}{PPN[2]} &
-\multicolumn{1}{c|}{PPN[1]} &
-\multicolumn{1}{c|}{PPN[0]} &
-\multicolumn{1}{c|}{RSW} &
-\multicolumn{1}{c|}{D} &
-\multicolumn{1}{c|}{A} &
-\multicolumn{1}{c|}{G} &
-\multicolumn{1}{c|}{U} &
-\multicolumn{1}{c|}{X} &
-\multicolumn{1}{c|}{W} &
-\multicolumn{1}{c|}{R} &
-\multicolumn{1}{c|}{V} \\
-\hline
-16 & 2 & 9 & 9 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
-\end{tabular}
-\end{center}
-}
-\vspace{-0.1in}
-\caption{Sv64 page table entry.}
-\label{sv64pte}
-\end{figure*}
-
-The PTE format for Sv64 is shown in Figure~\ref{sv64pte}.  Bits 9--0
-have the same meaning as for Sv32.  Any level of PTE may be a leaf
-PTE, so in addition to \wunits{4}{KiB} pages, Sv64 supports
-\wunits{2}{MiB} {\em megapages}, \wunits{1}{GiB} {\em gigapages},
-\wunits{512}{GiB} {\em terapages}, \wunits{256}{TiB} {\em petapages},
-and \wunits{128}{PiB} {\em exapages}, each of which must be virtually and
-physically aligned to a boundary equal to its size.
-
-The algorithm for virtual-to-physical address translation is the same
-as in Section~\ref{sv32algorithm}, except LEVELS equals 6, PTESIZE
-equals 8, and PPN[5]=0.

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -513,10 +513,10 @@ to the beginning of the instruction.
 \subsection{Supervisor Page-Table Base Register ({\tt sptbr})}
 \label{sec:sptbr}
 
-The {\tt sptbr} register is an XLEN-bit read/write register formatted as shown
-in Figure~\ref{rv32ptbrreg} for RV32 and Figure~\ref{rv64ptbrreg}.  The {\tt
-sptbr} register is only present on systems supporting paged virtual-memory
-systems.  This register holds the physical page number (PPN) of the root page
+The {\tt sptbr} register is an XLEN-bit read/write register, formatted as shown
+in Figure~\ref{rv32ptbrreg} for RV32 and Figure~\ref{rv64ptbrreg}, which
+controls supervisor-mode address translation and protection.
+This register holds the physical page number (PPN) of the root page
 table, i.e., its supervisor physical address divided by \wunits{4}{KiB};
 an address space identifier (ASID), which facilitates address-translation
 fences on a per-address-space basis; and the MODE field, which selects the
@@ -579,7 +579,7 @@ a context switch.
 \end{commentary}
 
 Table~\ref{tab:sptbr-mode} shows the encodings of the MODE field for RV32 and
-RV64.  When MODE=P, supervisor virtual addresses are equal to
+RV64.  When MODE=Bare, supervisor virtual addresses are equal to
 supervisor physical addresses, and there is no additional memory protection
 beyond the physical memory protection scheme described in
 Section~\ref{sec:pmp}.  In this case, the remaining fields in {\tt sptbr}
@@ -607,14 +607,14 @@ no effect; no fields in {\tt sptbr} are modified.
 \hline
 Value  & Name & Description \\
 \hline
-0       & P     & No translation or protection. \\
+0       & Bare  & No translation or protection. \\
 1       & Sv32  & Page-based 32-bit virtual addressing. \\
 \hline \hline
 \multicolumn{3}{|c|}{RV64} \\
 \hline
 Value  & Name & Description \\
 \hline  
-0       & P     & No translation or protection. \\
+0       & Bare  & No translation or protection. \\
 1--7    & ---   & {\em Reserved} \\
 8       & Sv39  & Page-based 39-bit virtual addressing. \\
 9       & Sv48  & Page-based 48-bit virtual addressing. \\

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -1038,7 +1038,7 @@ into \wunits{4}{KiB} pages.  An Sv39 address is partitioned as
 shown in Figure~\ref{sv39va}.  Load and store effective addresses,
 which are 64 bits, must have bits 63--39 all equal to bit 38, or else
 an access fault will occur.  The 27-bit VPN is translated into a
-38-bit PPN via a three-level page table, while the 12-bit page offset
+44-bit PPN via a three-level page table, while the 12-bit page offset
 is untranslated.
 
 \begin{figure*}[h!]
@@ -1068,7 +1068,7 @@ is untranslated.
 {\footnotesize
 \begin{center}
 \begin{tabular}{@{}T@{}O@{}O@{}O}
-\instbitrange{49}{30} &
+\instbitrange{55}{30} &
 \instbitrange{29}{21} &
 \instbitrange{20}{12} &
 \instbitrange{11}{0} \\
@@ -1078,7 +1078,7 @@ is untranslated.
 \multicolumn{1}{c|}{PPN[0]} &
 \multicolumn{1}{c|}{page offset} \\
 \hline
-20 & 9 & 9 & 12 \\
+26 & 9 & 9 & 12 \\
 \end{tabular}
 \end{center}
 }
@@ -1091,8 +1091,8 @@ is untranslated.
 {\footnotesize
 \begin{center}
 \begin{tabular}{@{}Y@{}Y@{}Y@{}Y@{}Fcccccccc}
-\instbitrange{63}{48} &
-\instbitrange{47}{28} &
+\instbitrange{63}{54} &
+\instbitrange{53}{28} &
 \instbitrange{27}{19} &
 \instbitrange{18}{10} &
 \instbitrange{9}{8} &
@@ -1119,7 +1119,7 @@ is untranslated.
 \multicolumn{1}{c|}{R} &
 \multicolumn{1}{c|}{V} \\
 \hline
-16 & 20 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
+10 & 26 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
 \end{tabular}
 \end{center}
 }
@@ -1134,7 +1134,7 @@ always be aligned to a page boundary.  The physical address of the
 root page table is stored in the {\tt sptbr} register.
 
 The PTE format for Sv39 is shown in Figure~\ref{sv39pte}.  Bits 9--0
-have the same meaning as for Sv32.  Bits 63--48 are reserved
+have the same meaning as for Sv32.  Bits 63--54 are reserved
 for future use and must be zeroed by software for forward compatibility.
 
 \begin{commentary}
@@ -1142,8 +1142,8 @@ We reserved several PTE bits for a possible extension that improves
 support for sparse address spaces by allowing page-table levels to be
 skipped, reducing memory usage and TLB refill latency.  These reserved
 bits may also be used to facilitate research experimentation.  The
-cost is reducing the physical address space, but \wunits{1}{PiB} is
-presently ample.  If at some point it no longer suffices, the reserved
+cost is reducing the physical address space, but \wunits{64}{PiB} is
+presently ample.  When it no longer suffices, the reserved
 bits that remain unallocated could be used to expand the physical
 address space.
 \end{commentary}
@@ -1181,7 +1181,7 @@ into \wunits{4}{KiB} pages.  An Sv48 address is partitioned as
 shown in Figure~\ref{sv48va}.  Load and store effective addresses,
 which are 64 bits, must have bits 63--48 all equal to bit 47, or else
 an access fault will occur.  The 36-bit VPN is translated into a
-38-bit PPN via a four-level page table, while the 12-bit page offset
+44-bit PPN via a four-level page table, while the 12-bit page offset
 is untranslated.
 
 \begin{figure*}[h!]
@@ -1213,7 +1213,7 @@ is untranslated.
 {\footnotesize
 \begin{center}
 \begin{tabular}{@{}E@{}O@{}O@{}O@{}O}
-\instbitrange{49}{39} &
+\instbitrange{55}{39} &
 \instbitrange{38}{30} &
 \instbitrange{29}{21} &
 \instbitrange{20}{12} &
@@ -1225,7 +1225,7 @@ is untranslated.
 \multicolumn{1}{c|}{PPN[0]} &
 \multicolumn{1}{c|}{page offset} \\
 \hline
-11 & 9 & 9 & 9 & 12 \\
+17 & 9 & 9 & 9 & 12 \\
 \end{tabular}
 \end{center}
 }
@@ -1238,8 +1238,8 @@ is untranslated.
 {\footnotesize
 \begin{center}
 \begin{tabular}{@{}Y@{}Y@{}Y@{}Y@{}Y@{}Fcccccccc}
-\instbitrange{63}{48} &
-\instbitrange{47}{37} &
+\instbitrange{63}{54} &
+\instbitrange{53}{37} &
 \instbitrange{36}{28} &
 \instbitrange{27}{19} &
 \instbitrange{18}{10} &
@@ -1268,7 +1268,7 @@ is untranslated.
 \multicolumn{1}{c|}{R} &
 \multicolumn{1}{c|}{V} \\
 \hline
-16 & 11 & 9 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
+10 & 17 & 9 & 9 & 9 & 2 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\\
 \end{tabular}
 \end{center}
 }

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -126,10 +126,10 @@ sstatus} is equivalent to reading or writing the homonymous field in
 
 \subsection{Base ISA Control in {\tt sstatus} Register}
 
-The UX field controls the value of XLEN for U-mode.  The encoding of UX is the
+The UXL field controls the value of XLEN for U-mode.  The encoding of UXL is the
 same as that of the Base field of {\tt misa}, shown in Table~\ref{misabase}.
 This field only exists for RV64 and RV128; RV32 machines always use RV32 for
-U-mode.  An implementation may limit the values to which UX can be set, but
+U-mode.  An implementation may limit the values to which UXL can be set, but
 U-mode XLEN must not exceed S-mode XLEN.
 
 \note{AW: add this to sstatus figure}

--- a/src/t.tex
+++ b/src/t.tex
@@ -1,5 +1,5 @@
 \chapter{``T'' Standard Extension for Transactional Memory, Version 0.0}
-\label{sec:bits}
+\label{sec:tm}
 
 This chapter is a placeholder for a future standard extension to
 provide transactional memory operations.


### PR DESCRIPTION
Make two's compliment explicit early on (in introduction).

Two's compliment is implicit elsewhere in the document;
Technically, operations define the encoding type,
and two's complimant is almost universal,
but it still is valuable to make the sign encoding explicit (IMO).